### PR TITLE
feat: 회원 도메인 정의

### DIFF
--- a/src/main/java/com/daangn/member/domain/Member.java
+++ b/src/main/java/com/daangn/member/domain/Member.java
@@ -1,0 +1,45 @@
+package com.daangn.member.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+/**
+ * 회원.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "member_id")
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    private String nickName;
+
+    private String imageUrl;
+
+    private double mannerTemperature = 36.5;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    @Builder
+    private Member(Long id, String email, String password, String nickName, String imageUrl, MemberStatus status) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.nickName = nickName;
+        this.imageUrl = imageUrl;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/daangn/member/domain/MemberStatus.java
+++ b/src/main/java/com/daangn/member/domain/MemberStatus.java
@@ -1,0 +1,10 @@
+package com.daangn.member.domain;
+
+/**
+ * 회원 상태.
+ */
+public enum MemberStatus {
+    ACTIVATE,
+    INACTIVATE,
+    DELETED,
+}

--- a/src/test/java/com/daangn/member/domain/MemberTest.java
+++ b/src/test/java/com/daangn/member/domain/MemberTest.java
@@ -1,0 +1,33 @@
+package com.daangn.member.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTest {
+
+    @Test
+    void newMember() {
+        String email = "test@test.com";
+        String password = "12345678";
+        String nickName = "당근";
+        String imageUrl = "http://image.com";
+        MemberStatus status = MemberStatus.ACTIVATE;
+        double defaultMannerTemperature = 36.5;
+
+        Member member = Member.builder()
+                .email(email)
+                .password(password)
+                .nickName(nickName)
+                .imageUrl(imageUrl)
+                .status(status)
+                .build();
+
+        assertThat(member.getEmail()).isEqualTo(email);
+        assertThat(member.getPassword()).isEqualTo(password);
+        assertThat(member.getNickName()).isEqualTo(nickName);
+        assertThat(member.getImageUrl()).isEqualTo(imageUrl);
+        assertThat(member.getStatus()).isEqualTo(status);
+        assertThat(member.getMannerTemperature()).isEqualTo(defaultMannerTemperature);
+    }
+}


### PR DESCRIPTION
- 식별자, 이메일, 비밀번호, 닉네임, 프로필 이미지 경로, 상태, 매너 온도를 가진 회원 도메인 정의