### PR TITLE
feat: 로그인 기능 구현

### DIFF
--- a/src/main/java/com/daangn/auth/config/SecurityConfig.java
+++ b/src/main/java/com/daangn/auth/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.daangn.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .csrf()
+                .disable();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/daangn/auth/controller/AuthController.java
+++ b/src/main/java/com/daangn/auth/controller/AuthController.java
@@ -24,5 +24,5 @@ public class AuthController {
         return ResponseEntity.ok()
                 .body(authService.login(loginRequestDTO));
     }
-    
+
 }

--- a/src/main/java/com/daangn/auth/controller/AuthController.java
+++ b/src/main/java/com/daangn/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.daangn.auth.controller;
+
+import com.daangn.auth.dto.LoginRequestDTO;
+import com.daangn.auth.dto.TokenResponseDTO;
+import com.daangn.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@Controller
+@RequestMapping(value = "/api/members")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signin")
+    public ResponseEntity<TokenResponseDTO> login(@RequestBody @Valid LoginRequestDTO loginRequestDTO) {
+        return ResponseEntity.ok()
+                .body(authService.login(loginRequestDTO));
+    }
+    
+}

--- a/src/main/java/com/daangn/auth/domain/TokenMember.java
+++ b/src/main/java/com/daangn/auth/domain/TokenMember.java
@@ -1,0 +1,11 @@
+package com.daangn.auth.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TokenMember {
+}

--- a/src/main/java/com/daangn/auth/dto/LoginRequestDTO.java
+++ b/src/main/java/com/daangn/auth/dto/LoginRequestDTO.java
@@ -1,0 +1,25 @@
+package com.daangn.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoginRequestDTO {
+
+    @NotBlank
+    private String email;
+    @NotBlank
+    private String password;
+
+    @Builder
+    private LoginRequestDTO(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+}

--- a/src/main/java/com/daangn/auth/dto/TokenResponseDTO.java
+++ b/src/main/java/com/daangn/auth/dto/TokenResponseDTO.java
@@ -1,0 +1,19 @@
+package com.daangn.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TokenResponseDTO {
+
+    private String token;
+
+    @Builder
+    public TokenResponseDTO(String token) {
+        this.token = token;
+    }
+
+    public static TokenResponseDTO from(String token) {
+        return new TokenResponseDTO(token);
+    }
+}

--- a/src/main/java/com/daangn/auth/exceptions/AuthorizationUninvolvedException.java
+++ b/src/main/java/com/daangn/auth/exceptions/AuthorizationUninvolvedException.java
@@ -1,0 +1,14 @@
+package com.daangn.auth.exceptions;
+
+import com.daangn.common.exceptions.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class AuthorizationUninvolvedException extends BusinessException {
+
+    private static final String MESSAGE = "로그인이 필요합니다.";
+
+    public AuthorizationUninvolvedException() {
+        super(MESSAGE, HttpStatus.UNAUTHORIZED);
+    }
+
+}

--- a/src/main/java/com/daangn/auth/exceptions/InvalidTokenException.java
+++ b/src/main/java/com/daangn/auth/exceptions/InvalidTokenException.java
@@ -1,0 +1,13 @@
+package com.daangn.auth.exceptions;
+
+import com.daangn.common.exceptions.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidTokenException extends BusinessException {
+
+    private static final String MESSAGE = "로그인이 필요합니다.";
+
+    public InvalidTokenException() {
+        super(MESSAGE, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/daangn/auth/exceptions/TokenExpiredException.java
+++ b/src/main/java/com/daangn/auth/exceptions/TokenExpiredException.java
@@ -1,0 +1,13 @@
+package com.daangn.auth.exceptions;
+
+import com.daangn.common.exceptions.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class TokenExpiredException extends BusinessException {
+
+    private static final String MESSAGE = "로그인이 필요합니다.";
+
+    public TokenExpiredException() {
+        super(MESSAGE, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/daangn/auth/handler/AuthenticationArgumentResolver.java
+++ b/src/main/java/com/daangn/auth/handler/AuthenticationArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.daangn.auth.handler;
+
+import com.daangn.auth.domain.TokenMember;
+import com.daangn.auth.util.AuthorizationExtractor;
+import com.daangn.auth.util.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+@RequiredArgsConstructor
+@Component
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(TokenMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mvContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String token = AuthorizationExtractor.getTokenFromRequset((HttpServletRequest) webRequest.getNativeRequest());
+        return tokenProvider.getIdFromToken(token);
+    }
+
+}

--- a/src/main/java/com/daangn/auth/handler/AuthenticationInterceptor.java
+++ b/src/main/java/com/daangn/auth/handler/AuthenticationInterceptor.java
@@ -1,0 +1,25 @@
+package com.daangn.auth.handler;
+
+import com.daangn.auth.util.AuthorizationExtractor;
+import com.daangn.auth.util.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+@Component
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String token = AuthorizationExtractor.getTokenFromRequset(request);
+        tokenProvider.validateToken(token);
+        return true;
+    }
+
+}

--- a/src/main/java/com/daangn/auth/service/AuthService.java
+++ b/src/main/java/com/daangn/auth/service/AuthService.java
@@ -1,0 +1,42 @@
+package com.daangn.auth.service;
+
+import com.daangn.auth.dto.LoginRequestDTO;
+import com.daangn.auth.dto.TokenResponseDTO;
+import com.daangn.auth.util.TokenProvider;
+import com.daangn.member.domain.Member;
+import com.daangn.member.exceptions.NotFoundMemberException;
+import com.daangn.member.exceptions.NotMatchMemberException;
+import com.daangn.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional(readOnly = true)
+    public TokenResponseDTO login(LoginRequestDTO loginRequestDTO) {
+        Member findMember = memberRepository.findByEmail(loginRequestDTO.getEmail())
+                .orElseThrow(() -> new NotFoundMemberException());
+        validatePassword(findMember, loginRequestDTO.getPassword());
+        String token = createToken(findMember.getId());
+        return TokenResponseDTO.from(token);
+    }
+
+    private String createToken(Long id) {
+        return tokenProvider.createToken(String.valueOf(id));
+    }
+
+    private void validatePassword(Member member, String password) {
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new NotMatchMemberException();
+        }
+    }
+
+}

--- a/src/main/java/com/daangn/auth/util/AuthorizationExtractor.java
+++ b/src/main/java/com/daangn/auth/util/AuthorizationExtractor.java
@@ -1,0 +1,21 @@
+package com.daangn.auth.util;
+
+import com.daangn.auth.exceptions.AuthorizationUninvolvedException;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class AuthorizationExtractor {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static String BEARER_TYPE = "Bearer ";
+
+    public static String getTokenFromRequset(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_TYPE)) {
+            return bearerToken.substring(7);
+        }
+        throw new AuthorizationUninvolvedException();
+    }
+    
+}

--- a/src/main/java/com/daangn/auth/util/AuthorizationExtractor.java
+++ b/src/main/java/com/daangn/auth/util/AuthorizationExtractor.java
@@ -13,9 +13,9 @@ public class AuthorizationExtractor {
     public static String getTokenFromRequset(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_TYPE)) {
-            return bearerToken.substring(7);
+            return bearerToken.substring(BEARER_TYPE.length());
         }
         throw new AuthorizationUninvolvedException();
     }
-    
+
 }

--- a/src/main/java/com/daangn/auth/util/TokenProvider.java
+++ b/src/main/java/com/daangn/auth/util/TokenProvider.java
@@ -1,0 +1,76 @@
+package com.daangn.auth.util;
+
+import com.daangn.auth.exceptions.InvalidTokenException;
+import com.daangn.auth.exceptions.TokenExpiredException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * 토큰 생성 및 검증
+ */
+@RequiredArgsConstructor
+@Component
+public class TokenProvider implements InitializingBean {
+
+    @Value("${jwt.token.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.token.expired-time}")
+    private long validityInMilliseconds;
+
+    private Key key;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    public String createToken(String subject) {
+        Claims claims = Jwts.claims().setSubject(subject);
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(validity)
+                .signWith(key)
+                .compact();
+    }
+
+    public String getIdFromToken(String authToken) {
+        Claims claims = getClaims(authToken);
+        return claims.get("id", String.class);
+    }
+
+    public boolean validateToken(String authToken) {
+        try {
+            Jws<Claims> claim = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(authToken);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
+        }
+    }
+
+    private Claims getClaims(String authToken) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(authToken)
+                .getBody();
+    }
+
+}

--- a/src/main/java/com/daangn/common/advice/CommonAdvice.java
+++ b/src/main/java/com/daangn/common/advice/CommonAdvice.java
@@ -1,0 +1,39 @@
+package com.daangn.common.advice;
+
+import com.daangn.common.dto.ErrorResponse;
+import com.daangn.common.exceptions.BusinessException;
+import com.daangn.common.exceptions.InputFieldException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CommonAdvice {
+
+    private final Logger LOG = LoggerFactory.getLogger(CommonAdvice.class);
+
+    @ExceptionHandler(InputFieldException.class)
+    public ResponseEntity<ErrorResponse> inputFieldExceptionHandler(final InputFieldException exception) {
+        LOG.error(exception.getMessage());
+        return ResponseEntity
+                .status(exception.getHttpStatus())
+                .body(ErrorResponse.from(exception));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> businessExceptionHandler(final BusinessException exception) {
+        LOG.error(exception.getMessage());
+        return ResponseEntity
+                .status(exception.getHttpStatus())
+                .body(ErrorResponse.from(exception));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Void> unhandledExceptionHandler(final Exception exception) {
+        LOG.warn(exception.getMessage(), exception);
+        return ResponseEntity.internalServerError().build();
+    }
+    
+}

--- a/src/main/java/com/daangn/common/advice/CommonAdvice.java
+++ b/src/main/java/com/daangn/common/advice/CommonAdvice.java
@@ -1,6 +1,7 @@
 package com.daangn.common.advice;
 
 import com.daangn.common.dto.ErrorResponse;
+import com.daangn.common.dto.InputFieldErrorResponse;
 import com.daangn.common.exceptions.BusinessException;
 import com.daangn.common.exceptions.InputFieldException;
 import org.slf4j.Logger;
@@ -15,11 +16,11 @@ public class CommonAdvice {
     private final Logger LOG = LoggerFactory.getLogger(CommonAdvice.class);
 
     @ExceptionHandler(InputFieldException.class)
-    public ResponseEntity<ErrorResponse> inputFieldExceptionHandler(final InputFieldException exception) {
+    public ResponseEntity<InputFieldErrorResponse> inputFieldExceptionHandler(final InputFieldException exception) {
         LOG.error(exception.getMessage());
         return ResponseEntity
                 .status(exception.getHttpStatus())
-                .body(ErrorResponse.from(exception));
+                .body(InputFieldErrorResponse.from(exception));
     }
 
     @ExceptionHandler(BusinessException.class)
@@ -35,5 +36,5 @@ public class CommonAdvice {
         LOG.warn(exception.getMessage(), exception);
         return ResponseEntity.internalServerError().build();
     }
-    
+
 }

--- a/src/main/java/com/daangn/common/config/WebMvcConfig.java
+++ b/src/main/java/com/daangn/common/config/WebMvcConfig.java
@@ -1,0 +1,39 @@
+package com.daangn.common.config;
+
+import com.daangn.auth.handler.AuthenticationArgumentResolver;
+import com.daangn.auth.handler.AuthenticationInterceptor;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthenticationArgumentResolver authenticationArgumentResolver;
+    private final AuthenticationInterceptor authenticationInterceptor;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        List<String> addPath = List.of(
+
+        );
+        List<String> excludePath = List.of(
+                "api/members/signin"
+        );
+        registry.addInterceptor(authenticationInterceptor)
+                .addPathPatterns(addPath)
+                .excludePathPatterns(excludePath);
+    }
+
+}

--- a/src/main/java/com/daangn/common/dto/ErrorResponse.java
+++ b/src/main/java/com/daangn/common/dto/ErrorResponse.java
@@ -1,14 +1,14 @@
 package com.daangn.common.dto;
 
 public class ErrorResponse {
-    
+
     private String message;
 
     protected ErrorResponse(final String message) {
         this.message = message;
     }
 
-    public static ErrorResponse from(final RuntimeException exception) {
+    public static ErrorResponse from(RuntimeException exception) {
         return new ErrorResponse(exception.getMessage());
     }
 

--- a/src/main/java/com/daangn/common/dto/ErrorResponse.java
+++ b/src/main/java/com/daangn/common/dto/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.daangn.common.dto;
+
+public class ErrorResponse {
+    
+    private String message;
+
+    protected ErrorResponse(final String message) {
+        this.message = message;
+    }
+
+    public static ErrorResponse from(final RuntimeException exception) {
+        return new ErrorResponse(exception.getMessage());
+    }
+
+}

--- a/src/main/java/com/daangn/common/dto/InputFieldErrorResponse.java
+++ b/src/main/java/com/daangn/common/dto/InputFieldErrorResponse.java
@@ -1,0 +1,20 @@
+package com.daangn.common.dto;
+
+import com.daangn.common.exceptions.InputFieldException;
+import lombok.Getter;
+
+@Getter
+public class InputFieldErrorResponse extends ErrorResponse {
+
+    private String field;
+
+    protected InputFieldErrorResponse(String message, String field) {
+        super(message);
+        this.field = field;
+    }
+
+    public static InputFieldErrorResponse from(InputFieldException exception) {
+        return new InputFieldErrorResponse(exception.getMessage(), exception.getField());
+    }
+
+}

--- a/src/main/java/com/daangn/common/exceptions/BusinessException.java
+++ b/src/main/java/com/daangn/common/exceptions/BusinessException.java
@@ -1,0 +1,16 @@
+package com.daangn.common.exceptions;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+
+    public BusinessException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+}

--- a/src/main/java/com/daangn/common/exceptions/InputFieldException.java
+++ b/src/main/java/com/daangn/common/exceptions/InputFieldException.java
@@ -1,0 +1,19 @@
+package com.daangn.common.exceptions;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class InputFieldException extends BusinessException {
+
+    protected static final String EMAIL = "email";
+    protected static final String PASSWORD = "password";
+
+    private final String field;
+
+    public InputFieldException(String message, HttpStatus httpStatus, String field) {
+        super(message, httpStatus);
+        this.field = field;
+    }
+
+}

--- a/src/main/java/com/daangn/member/exceptions/NotFoundMemberException.java
+++ b/src/main/java/com/daangn/member/exceptions/NotFoundMemberException.java
@@ -1,0 +1,14 @@
+package com.daangn.member.exceptions;
+
+import com.daangn.common.exceptions.InputFieldException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundMemberException extends InputFieldException {
+
+    private static final String MESSAGE = "존재하지 않는 회원입니다.";
+
+    public NotFoundMemberException() {
+        super(MESSAGE, HttpStatus.NOT_FOUND, EMAIL);
+    }
+    
+}

--- a/src/main/java/com/daangn/member/exceptions/NotMatchMemberException.java
+++ b/src/main/java/com/daangn/member/exceptions/NotMatchMemberException.java
@@ -1,0 +1,14 @@
+package com.daangn.member.exceptions;
+
+import com.daangn.common.exceptions.InputFieldException;
+import org.springframework.http.HttpStatus;
+
+public class NotMatchMemberException extends InputFieldException {
+
+    private static final String MESSAGE = "이메일 혹은 비밀번호를 확인해주세요.";
+
+    public NotMatchMemberException() {
+        super(MESSAGE, HttpStatus.BAD_REQUEST, PASSWORD);
+    }
+
+}

--- a/src/main/java/com/daangn/member/repository/MemberRepository.java
+++ b/src/main/java/com/daangn/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.daangn.member.repository;
+
+import com.daangn.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+    
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+jwt.token.secret-key=secretsecretsecretsecretsecret
+jwt.token.expired-time=3600000 

--- a/src/test/java/com/daangn/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/daangn/auth/controller/AuthControllerTest.java
@@ -1,0 +1,59 @@
+package com.daangn.auth.controller;
+
+import com.daangn.auth.dto.LoginRequestDTO;
+import com.daangn.auth.dto.TokenResponseDTO;
+import com.daangn.auth.service.AuthService;
+import com.daangn.auth.util.TokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    LoginRequestDTO loginRequestDTO;
+
+    @BeforeEach
+    void setup() {
+        loginRequestDTO = LoginRequestDTO.builder()
+                .email("test@test.com")
+                .password("12345678")
+                .build();
+    }
+
+    @Test
+    void 로그인_성공() throws Exception {
+        given(authService.login(any(LoginRequestDTO.class)))
+                .willReturn(TokenResponseDTO.builder()
+                        .token("1.2.3")
+                        .build());
+
+        mockMvc.perform(post("/api/members/signin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequestDTO)))
+                .andExpect(status().isOk());
+    }
+
+}


### PR DESCRIPTION
- /api/members/singin 로그인 요청 시 유효한 회원의 email, password일 경우 id로 token을 발급합니다.